### PR TITLE
Various builder and fetcher clean-ups

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -30,7 +30,7 @@ public interface KafkaClient extends Closeable {
      * @param node The node to check
      * @param now The current timestamp
      */
-    public boolean isReady(Node node, long now);
+    boolean isReady(Node node, long now);
 
     /**
      * Initiate a connection to the given node (if necessary), and return true if already connected. The readiness of a
@@ -40,7 +40,7 @@ public interface KafkaClient extends Closeable {
      * @param now The current time
      * @return true iff we are ready to immediately initiate the sending of another request to the given node.
      */
-    public boolean ready(Node node, long now);
+    boolean ready(Node node, long now);
 
     /**
      * Returns the number of milliseconds to wait, based on the connection state, before attempting to send data. When
@@ -51,7 +51,7 @@ public interface KafkaClient extends Closeable {
      * @param now The current timestamp
      * @return The number of milliseconds to wait.
      */
-    public long connectionDelay(Node node, long now);
+    long connectionDelay(Node node, long now);
 
     /**
      * Check if the connection of the node has failed, based on the connection state. Such connection failure are
@@ -61,14 +61,14 @@ public interface KafkaClient extends Closeable {
      * @param node the node to check
      * @return true iff the connection has failed and the node is disconnected
      */
-    public boolean connectionFailed(Node node);
+    boolean connectionFailed(Node node);
 
     /**
      * Queue up the given request for sending. Requests can only be sent on ready connections.
      * @param request The request
      * @param now The current timestamp
      */
-    public void send(ClientRequest request, long now);
+    void send(ClientRequest request, long now);
 
     /**
      * Do actual reads and writes from sockets.
@@ -79,14 +79,14 @@ public interface KafkaClient extends Closeable {
      * @param now The current time in ms
      * @throws IllegalStateException If a request is sent to an unready node
      */
-    public List<ClientResponse> poll(long timeout, long now);
+    List<ClientResponse> poll(long timeout, long now);
 
     /**
      * Closes the connection to a particular node (if there is one).
      *
      * @param nodeId The id of the node
      */
-    public void close(String nodeId);
+    void close(String nodeId);
 
     /**
      * Choose the node with the fewest outstanding requests. This method will prefer a node with an existing connection,
@@ -96,24 +96,35 @@ public interface KafkaClient extends Closeable {
      * @param now The current time in ms
      * @return The node with the fewest in-flight requests.
      */
-    public Node leastLoadedNode(long now);
+    Node leastLoadedNode(long now);
 
     /**
      * The number of currently in-flight requests for which we have not yet returned a response
      */
-    public int inFlightRequestCount();
+    int inFlightRequestCount();
 
     /**
      * Get the total in-flight requests for a particular node
      * 
      * @param nodeId The id of the node
      */
-    public int inFlightRequestCount(String nodeId);
+    int inFlightRequestCount(String nodeId);
 
     /**
      * Wake up the client if it is currently blocked waiting for I/O
      */
-    public void wakeup();
+    void wakeup();
+
+    /**
+     * Create a new ClientRequest.
+     *
+     * @param nodeId the node to send to
+     * @param requestBuilder the request builder to use
+     * @param createdTimeMs the time in milliseconds to use as the creation time of the request
+     * @param expectResponse true iff we expect a response
+     */
+    ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder,
+                                   long createdTimeMs, boolean expectResponse);
 
     /**
      * Create a new ClientRequest.
@@ -123,9 +134,8 @@ public interface KafkaClient extends Closeable {
      * @param createdTimeMs the time in milliseconds to use as the creation time of the request
      * @param expectResponse true iff we expect a response
      * @param callback the callback to invoke when we get a response
-     * @return
      */
-    public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder requestBuilder,
+    ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder,
                                           long createdTimeMs, boolean expectResponse,
                                           RequestCompletionHandler callback);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -265,7 +265,7 @@ public class NetworkClient implements KafkaClient {
 
     private void sendInternalMetadataRequest(MetadataRequest.Builder builder,
                                              String nodeConnectionId, long now) {
-        ClientRequest clientRequest = newClientRequest(nodeConnectionId, builder, now, true, null);
+        ClientRequest clientRequest = newClientRequest(nodeConnectionId, builder, now, true);
         doSend(clientRequest, true, now);
     }
 
@@ -590,7 +590,7 @@ public class NetworkClient implements KafkaClient {
             if (selector.isChannelReady(node) && inFlightRequests.canSendMore(node)) {
                 log.debug("Initiating API versions fetch from node {}.", node);
                 ApiVersionsRequest.Builder apiVersionRequest = new ApiVersionsRequest.Builder();
-                ClientRequest clientRequest = newClientRequest(node, apiVersionRequest, now, true, null);
+                ClientRequest clientRequest = newClientRequest(node, apiVersionRequest, now, true);
                 doSend(clientRequest, true, now);
                 iter.remove();
             }
@@ -766,11 +766,16 @@ public class NetworkClient implements KafkaClient {
     }
 
     @Override
-    public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder requestBuilder,
-                                          long createdTimeMs, boolean expectResponse,
-                                          RequestCompletionHandler callback) {
-        return new ClientRequest(nodeId, requestBuilder, correlation++, clientId,
-                createdTimeMs, expectResponse, callback);
+    public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
+                                          boolean expectResponse) {
+        return newClientRequest(nodeId, requestBuilder, createdTimeMs, expectResponse, null);
+    }
+
+    @Override
+    public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
+                                          boolean expectResponse, RequestCompletionHandler callback) {
+        return new ClientRequest(nodeId, requestBuilder, correlation++, clientId, createdTimeMs, expectResponse,
+                callback);
     }
 
     static class InFlightRequest {

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -295,8 +295,8 @@ public class NetworkClient implements KafkaClient {
             } else {
                 short version = versionInfo.usableVersion(clientRequest.apiKey());
                 if (log.isTraceEnabled())
-                    log.trace("When sending message of type {} to node {}, the best usable " +
-                            "version is {}", clientRequest.apiKey(), nodeId, version);
+                    log.trace("When sending message of type {} to node {}, the best usable version is {}",
+                            clientRequest.apiKey(), nodeId, version);
                 builder.setVersion(version);
             }
             // The call to build may also throw UnsupportedVersionException, if there are essential
@@ -482,7 +482,7 @@ public class NetworkClient implements KafkaClient {
         }
 
         // we disconnected, so we should probably refresh our metadata
-        if (nodeIds.size() > 0)
+        if (!nodeIds.isEmpty())
             metadataUpdater.requestUpdate();
     }
 
@@ -539,9 +539,8 @@ public class NetworkClient implements KafkaClient {
             processDisconnection(responses, node, now);
             return;
         }
-        int nodeId = Integer.parseInt(node);
         NodeApiVersions nodeVersionInfo = new NodeApiVersions(apiVersionsResponse.apiVersions());
-        nodeApiVersions.put(String.valueOf(nodeId), nodeVersionInfo);
+        nodeApiVersions.put(node, nodeVersionInfo);
         this.connectionStates.ready(node);
         if (log.isDebugEnabled()) {
             log.debug("Recorded API versions for node {}: {}", node, nodeVersionInfo);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -94,8 +94,8 @@ public class ConsumerNetworkClient implements Closeable {
                                               AbstractRequest.Builder requestBuilder) {
         long now = time.milliseconds();
         RequestFutureCompletionHandler completionHandler = new RequestFutureCompletionHandler();
-        ClientRequest clientRequest = client.newClientRequest(node.idString(),
-                requestBuilder, now, true, completionHandler);
+        ClientRequest clientRequest = client.newClientRequest(node.idString(), requestBuilder, now, true,
+                completionHandler);
         put(node, clientRequest);
 
         // wakeup the client in case it is blocking in poll so that we can send the queued request

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -356,9 +356,7 @@ public class Sender implements Runnable {
         };
 
         String nodeId = Integer.toString(destination);
-        ClientRequest clientRequest = client.
-                newClientRequest(nodeId, requestBuilder, now, acks != 0, callback);
-
+        ClientRequest clientRequest = client.newClientRequest(nodeId, requestBuilder, now, acks != 0, callback);
         client.send(clientRequest, now);
         log.trace("Sent produce request to {}: {}", nodeId, requestBuilder);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ControlledShutdownRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ControlledShutdownRequest.java
@@ -25,7 +25,7 @@ public class ControlledShutdownRequest extends AbstractRequest {
     private static final String BROKER_ID_KEY_NAME = "broker_id";
 
     public static class Builder extends AbstractRequest.Builder<ControlledShutdownRequest> {
-        private int brokerId;
+        private final int brokerId;
 
         public Builder(int brokerId) {
             super(ApiKeys.CONTROLLED_SHUTDOWN_KEY);
@@ -81,8 +81,7 @@ public class ControlledShutdownRequest extends AbstractRequest {
 
     public static ControlledShutdownRequest parse(ByteBuffer buffer, int versionId) {
         return new ControlledShutdownRequest(
-                ProtoUtils.parseRequest(ApiKeys.CONTROLLED_SHUTDOWN_KEY.id, versionId, buffer),
-                (short) versionId);
+                ProtoUtils.parseRequest(ApiKeys.CONTROLLED_SHUTDOWN_KEY.id, versionId, buffer), (short) versionId);
     }
 
     public static ControlledShutdownRequest parse(ByteBuffer buffer) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsRequest.java
@@ -95,8 +95,8 @@ public class CreateTopicsRequest extends AbstractRequest {
     }
 
     public static class Builder extends AbstractRequest.Builder<CreateTopicsRequest> {
-        private Map<String, TopicDetails> topics;
-        private Integer timeout;
+        private final Map<String, TopicDetails> topics;
+        private final Integer timeout;
 
         public Builder(Map<String, TopicDetails> topics, Integer timeout) {
             super(ApiKeys.CREATE_TOPICS);

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
@@ -36,8 +36,8 @@ public class DeleteTopicsRequest extends AbstractRequest {
     private final Integer timeout;
 
     public static class Builder extends AbstractRequest.Builder<DeleteTopicsRequest> {
-        private Set<String> topics;
-        private Integer timeout;
+        private final Set<String> topics;
+        private final Integer timeout;
 
         public Builder(Set<String> topics, Integer timeout) {
             super(ApiKeys.DELETE_TOPICS);
@@ -106,8 +106,7 @@ public class DeleteTopicsRequest extends AbstractRequest {
     }
 
     public static DeleteTopicsRequest parse(ByteBuffer buffer, int versionId) {
-        return new DeleteTopicsRequest(
-                ProtoUtils.parseRequest(ApiKeys.DELETE_TOPICS.id, versionId, buffer),
+        return new DeleteTopicsRequest(ProtoUtils.parseRequest(ApiKeys.DELETE_TOPICS.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeGroupsRequest.java
@@ -26,16 +26,11 @@ public class DescribeGroupsRequest extends AbstractRequest {
     private static final String GROUP_IDS_KEY_NAME = "group_ids";
 
     public static class Builder extends AbstractRequest.Builder<DescribeGroupsRequest> {
-        private List<String> groupIds;
+        private final List<String> groupIds;
 
         public Builder(List<String> groupIds) {
             super(ApiKeys.DESCRIBE_GROUPS);
             this.groupIds = groupIds;
-        }
-
-        public Builder setGroupIds(List<String> groupIds) {
-            this.groupIds = groupIds;
-            return this;
         }
 
         @Override
@@ -84,8 +79,7 @@ public class DescribeGroupsRequest extends AbstractRequest {
     }
 
     public static DescribeGroupsRequest parse(ByteBuffer buffer, int versionId) {
-        return new DescribeGroupsRequest(
-                ProtoUtils.parseRequest(ApiKeys.DESCRIBE_GROUPS.id, versionId, buffer),
+        return new DescribeGroupsRequest(ProtoUtils.parseRequest(ApiKeys.DESCRIBE_GROUPS.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -94,7 +94,7 @@ public class FetchRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<FetchRequest> {
         private int replicaId = CONSUMER_REPLICA_ID;
         private int maxWait;
-        private int minBytes;
+        private final int minBytes;
         private int maxBytes = DEFAULT_RESPONSE_MAX_BYTES;
         private LinkedHashMap<TopicPartition, PartitionData> fetchData;
 
@@ -115,17 +115,12 @@ public class FetchRequest extends AbstractRequest {
             return this;
         }
 
-        public Builder setMinBytes(int minBytes) {
-            this.minBytes = minBytes;
-            return this;
-        }
-
         public Builder setMaxBytes(int maxBytes) {
             this.maxBytes = maxBytes;
             return this;
         }
 
-        public LinkedHashMap<TopicPartition, PartitionData> getFetchData() {
+        public LinkedHashMap<TopicPartition, PartitionData> fetchData() {
             return this.fetchData;
         }
 
@@ -133,7 +128,7 @@ public class FetchRequest extends AbstractRequest {
         public FetchRequest build() {
             short version = version();
             if (version < 3) {
-                maxBytes = DEFAULT_RESPONSE_MAX_BYTES;
+                maxBytes = -1;
             }
 
             return new FetchRequest(version, replicaId, maxWait, minBytes,
@@ -250,9 +245,7 @@ public class FetchRequest extends AbstractRequest {
     }
 
     public static FetchRequest parse(ByteBuffer buffer, int versionId) {
-        return new FetchRequest(
-                ProtoUtils.parseRequest(ApiKeys.FETCH.id, versionId, buffer),
-                (short) versionId);
+        return new FetchRequest(ProtoUtils.parseRequest(ApiKeys.FETCH.id, versionId, buffer), (short) versionId);
     }
 
     public static FetchRequest parse(ByteBuffer buffer) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/GroupCoordinatorRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/GroupCoordinatorRequest.java
@@ -24,16 +24,11 @@ public class GroupCoordinatorRequest extends AbstractRequest {
     private static final String GROUP_ID_KEY_NAME = "group_id";
 
     public static class Builder extends AbstractRequest.Builder<GroupCoordinatorRequest> {
-        private String groupId;
+        private final String groupId;
 
         public Builder(String groupId) {
             super(ApiKeys.GROUP_COORDINATOR);
             this.groupId = groupId;
-        }
-
-        public Builder setGroupId(String groupId) {
-            this.groupId = groupId;
-            return this;
         }
 
         @Override
@@ -82,8 +77,7 @@ public class GroupCoordinatorRequest extends AbstractRequest {
     }
 
     public static GroupCoordinatorRequest parse(ByteBuffer buffer, int versionId) {
-        return new GroupCoordinatorRequest(
-                ProtoUtils.parseRequest(ApiKeys.GROUP_COORDINATOR.id, versionId, buffer),
+        return new GroupCoordinatorRequest(ProtoUtils.parseRequest(ApiKeys.GROUP_COORDINATOR.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/HeartbeatRequest.java
@@ -25,30 +25,15 @@ public class HeartbeatRequest extends AbstractRequest {
     private static final String MEMBER_ID_KEY_NAME = "member_id";
 
     public static class Builder extends AbstractRequest.Builder<HeartbeatRequest> {
-        private String groupId;
-        private int groupGenerationId;
-        private String memberId;
+        private final String groupId;
+        private final int groupGenerationId;
+        private final String memberId;
 
         public Builder(String groupId, int groupGenerationId, String memberId) {
             super(ApiKeys.HEARTBEAT);
             this.groupId = groupId;
             this.groupGenerationId = groupGenerationId;
             this.memberId = memberId;
-        }
-
-        public Builder setGroupId(String groupId) {
-            this.groupId = groupId;
-            return this;
-        }
-
-        public Builder setMemberId(int groupGenerationId) {
-            this.groupGenerationId = groupGenerationId;
-            return this;
-        }
-
-        public Builder setMemberId(String memberId) {
-            this.memberId = memberId;
-            return this;
         }
 
         @Override
@@ -115,9 +100,7 @@ public class HeartbeatRequest extends AbstractRequest {
     }
 
     public static HeartbeatRequest parse(ByteBuffer buffer, int versionId) {
-        return new HeartbeatRequest(
-                ProtoUtils.parseRequest(ApiKeys.HEARTBEAT.id, versionId, buffer),
-                (short) versionId);
+        return new HeartbeatRequest(ProtoUtils.parseRequest(ApiKeys.HEARTBEAT.id, versionId, buffer), (short) versionId);
     }
 
     public static HeartbeatRequest parse(ByteBuffer buffer) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupRequest.java
@@ -61,12 +61,12 @@ public class JoinGroupRequest extends AbstractRequest {
     }
 
     public static class Builder extends AbstractRequest.Builder<JoinGroupRequest> {
-        private String groupId = null;
-        private int sessionTimeout = 0;
+        private final String groupId;
+        private final int sessionTimeout;
+        private final String memberId;
+        private final String protocolType;
+        private final List<ProtocolMetadata> groupProtocols;
         private int rebalanceTimeout = 0;
-        private String memberId = null;
-        private String protocolType = null;
-        private List<ProtocolMetadata> groupProtocols = null;
 
         public Builder(String groupId, int sessionTimeout, String memberId,
                        String protocolType, List<ProtocolMetadata> groupProtocols) {
@@ -79,38 +79,9 @@ public class JoinGroupRequest extends AbstractRequest {
             this.groupProtocols = groupProtocols;
         }
 
-        public Builder setGroupId(String groupId) {
-            this.groupId = groupId;
-            return this;
-        }
-
-        public Builder setSessionTimeout(int sessionTimeout) {
-            this.sessionTimeout = sessionTimeout;
-            return this;
-        }
-
         public Builder setRebalanceTimeout(int rebalanceTimeout) {
             this.rebalanceTimeout = rebalanceTimeout;
             return this;
-        }
-
-        public Builder setMemberId(String memberId) {
-            this.memberId = memberId;
-            return this;
-        }
-
-        public Builder setProtocolType(String protocolType) {
-            this.protocolType = protocolType;
-            return this;
-        }
-
-        public Builder setGroupProtocols(List<ProtocolMetadata> groupProtocols) {
-            this.groupProtocols = groupProtocols;
-            return this;
-        }
-
-        public List<ProtocolMetadata> getGroupProtocols() {
-            return groupProtocols;
         }
 
         @Override
@@ -237,8 +208,7 @@ public class JoinGroupRequest extends AbstractRequest {
     }
 
     public static JoinGroupRequest parse(ByteBuffer buffer, int versionId) {
-        return new JoinGroupRequest(
-                ProtoUtils.parseRequest(ApiKeys.JOIN_GROUP.id, versionId, buffer),
+        return new JoinGroupRequest(ProtoUtils.parseRequest(ApiKeys.JOIN_GROUP.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
@@ -54,10 +54,10 @@ public class LeaderAndIsrRequest extends AbstractRequest {
     private static final String PORT_KEY_NAME = "port";
 
     public static class Builder extends AbstractRequest.Builder<LeaderAndIsrRequest> {
-        private int controllerId;
-        private int controllerEpoch;
-        private Map<TopicPartition, PartitionState> partitionStates;
-        private Set<Node> liveLeaders;
+        private final int controllerId;
+        private final int controllerEpoch;
+        private final Map<TopicPartition, PartitionState> partitionStates;
+        private final Set<Node> liveLeaders;
 
         public Builder(int controllerId, int controllerEpoch,
                        Map<TopicPartition, PartitionState> partitionStates, Set<Node> liveLeaders) {
@@ -210,8 +210,7 @@ public class LeaderAndIsrRequest extends AbstractRequest {
     }
 
     public static LeaderAndIsrRequest parse(ByteBuffer buffer, int versionId) {
-        return new LeaderAndIsrRequest(
-                ProtoUtils.parseRequest(ApiKeys.LEADER_AND_ISR.id, versionId, buffer),
+        return new LeaderAndIsrRequest(ProtoUtils.parseRequest(ApiKeys.LEADER_AND_ISR.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaveGroupRequest.java
@@ -23,23 +23,13 @@ public class LeaveGroupRequest extends AbstractRequest {
     private static final String MEMBER_ID_KEY_NAME = "member_id";
 
     public static class Builder extends AbstractRequest.Builder<LeaveGroupRequest> {
-        private String groupId;
-        private String memberId;
+        private final String groupId;
+        private final String memberId;
 
         public Builder(String groupId, String memberId) {
             super(ApiKeys.LEAVE_GROUP);
             this.groupId = groupId;
             this.memberId = memberId;
-        }
-
-        public Builder setGroupId(String groupId) {
-            this.groupId = groupId;
-            return this;
-        }
-
-        public Builder setMemberId(String memberId) {
-            this.memberId = memberId;
-            return this;
         }
 
         @Override
@@ -97,8 +87,8 @@ public class LeaveGroupRequest extends AbstractRequest {
     }
 
     public static LeaveGroupRequest parse(ByteBuffer buffer, int versionId) {
-        return new LeaveGroupRequest(
-                ProtoUtils.parseRequest(ApiKeys.LEAVE_GROUP.id, versionId, buffer), (short) versionId);
+        return new LeaveGroupRequest(ProtoUtils.parseRequest(ApiKeys.LEAVE_GROUP.id, versionId, buffer),
+                (short) versionId);
     }
 
     public static LeaveGroupRequest parse(ByteBuffer buffer) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListGroupsRequest.java
@@ -60,8 +60,7 @@ public class ListGroupsRequest extends AbstractRequest {
     }
 
     public static ListGroupsRequest parse(ByteBuffer buffer, int versionId) {
-        return new ListGroupsRequest(
-                ProtoUtils.parseRequest(ApiKeys.LIST_GROUPS.id, versionId, buffer),
+        return new ListGroupsRequest(ProtoUtils.parseRequest(ApiKeys.LIST_GROUPS.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
@@ -97,12 +97,12 @@ public class ListOffsetResponse extends AbstractResponse {
             bld.append("PartitionData{").
                 append("errorCode: ").append((int) errorCode).
                 append(", timestamp: ").append(timestamp).
-                append(", offset: ").append(offset);
+                append(", offset: ").append(offset).
+                append(", offsets: ");
             if (offsets == null) {
-                bld.append(", offsets: null");
+                bld.append(offsets);
             } else {
-                bld.append(", offsets: [").
-                    append(Utils.join(this.offsets, ",")).append("]");
+                bld.append("[").append(Utils.join(this.offsets, ",")).append("]");
             }
             bld.append("}");
             return bld.toString();

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -25,18 +25,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class MetadataRequest extends AbstractRequest {
-    private static final Logger log = LoggerFactory.getLogger(MetadataRequest.class);
 
     public static class Builder extends AbstractRequest.Builder<MetadataRequest> {
         private static final List<String> ALL_TOPICS = null;
 
-        // The list of topics, or null if we want to request metadata about all
-        // topics.
-        private List<String> topics;
+        // The list of topics, or null if we want to request metadata about all topics.
+        private final List<String> topics;
 
         public static Builder allTopics() {
             return new Builder(ALL_TOPICS);
@@ -128,14 +123,14 @@ public class MetadataRequest extends AbstractRequest {
         }
 
         short versionId = version();
-        switch (version()) {
+        switch (versionId) {
             case 0:
             case 1:
             case 2:
                 return new MetadataResponse(Collections.<Node>emptyList(), null, MetadataResponse.NO_CONTROLLER_ID, topicMetadatas, versionId);
             default:
                 throw new IllegalArgumentException(String.format("Version %d is not valid. Valid versions for %s are 0 to %d",
-                        version(), this.getClass().getSimpleName(), ProtoUtils.latestVersion(ApiKeys.METADATA.id)));
+                        versionId, this.getClass().getSimpleName(), ProtoUtils.latestVersion(ApiKeys.METADATA.id)));
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetCommitRequest.java
@@ -96,21 +96,16 @@ public class OffsetCommitRequest extends AbstractRequest {
     }
 
     public static class Builder extends AbstractRequest.Builder<OffsetCommitRequest> {
-        private String groupId;
+        private final String groupId;
+        private final Map<TopicPartition, PartitionData> offsetData;
         private String memberId = DEFAULT_MEMBER_ID;
         private int generationId = DEFAULT_GENERATION_ID;
         private long retentionTime = DEFAULT_RETENTION_TIME;
-        private Map<TopicPartition, PartitionData> offsetData;
 
         public Builder(String groupId, Map<TopicPartition, PartitionData> offsetData) {
             super(ApiKeys.OFFSET_COMMIT);
             this.groupId = groupId;
             this.offsetData = offsetData;
-        }
-
-        Builder setGroupId(String groupId) {
-            this.groupId = groupId;
-            return this;
         }
 
         public Builder setMemberId(String memberId) {
@@ -205,8 +200,7 @@ public class OffsetCommitRequest extends AbstractRequest {
      */
     private OffsetCommitRequest(String groupId, int generationId, String memberId, long retentionTime,
                                 Map<TopicPartition, PartitionData> offsetData, short version) {
-        super(new Struct(ProtoUtils.requestSchema(ApiKeys.OFFSET_COMMIT.id, version)),
-                version);
+        super(new Struct(ProtoUtils.requestSchema(ApiKeys.OFFSET_COMMIT.id, version)), version);
         initCommonFields(groupId, offsetData);
         struct.set(GENERATION_ID_KEY_NAME, generationId);
         struct.set(MEMBER_ID_KEY_NAME, memberId);
@@ -298,7 +292,6 @@ public class OffsetCommitRequest extends AbstractRequest {
 
         short versionId = version();
         switch (versionId) {
-            // OffsetCommitResponseV0 == OffsetCommitResponseV1 == OffsetCommitResponseV2
             case 0:
             case 1:
             case 2:

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchRequest.java
@@ -38,23 +38,13 @@ public class OffsetFetchRequest extends AbstractRequest {
     private static final String PARTITION_KEY_NAME = "partition";
 
     public static class Builder extends AbstractRequest.Builder<OffsetFetchRequest> {
-        private String groupId;
-        private List<TopicPartition> partitions;
+        private final String groupId;
+        private final List<TopicPartition> partitions;
 
         public Builder(String groupId, List<TopicPartition> partitions) {
             super(ApiKeys.OFFSET_FETCH);
             this.groupId = groupId;
             this.partitions = partitions;
-        }
-
-        public Builder setGroupId(String groupId) {
-            this.groupId = groupId;
-            return this;
-        }
-
-        public Builder setPartitions(List<TopicPartition> partitions) {
-            this.partitions = partitions;
-            return this;
         }
 
         @Override
@@ -78,8 +68,7 @@ public class OffsetFetchRequest extends AbstractRequest {
 
     // v0 and v1 have the same fields.
     private OffsetFetchRequest(String groupId, List<TopicPartition> partitions, short version) {
-        super(new Struct(ProtoUtils.requestSchema(ApiKeys.OFFSET_FETCH.id, version)),
-                version);
+        super(new Struct(ProtoUtils.requestSchema(ApiKeys.OFFSET_FETCH.id, version)), version);
         Map<String, List<Integer>> topicsData = CollectionUtils.groupDataByTopic(partitions);
 
         struct.set(GROUP_ID_KEY_NAME, groupId);
@@ -128,7 +117,6 @@ public class OffsetFetchRequest extends AbstractRequest {
 
         short versionId = version();
         switch (versionId) {
-            // OffsetFetchResponseV0 == OffsetFetchResponseV1
             case 0:
             case 1:
                 return new OffsetFetchResponse(responseData);
@@ -147,8 +135,7 @@ public class OffsetFetchRequest extends AbstractRequest {
     }
 
     public static OffsetFetchRequest parse(ByteBuffer buffer, int versionId) {
-        return new OffsetFetchRequest(
-                ProtoUtils.parseRequest(ApiKeys.OFFSET_FETCH.id, versionId, buffer),
+        return new OffsetFetchRequest(ProtoUtils.parseRequest(ApiKeys.OFFSET_FETCH.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -44,9 +44,9 @@ public class ProduceRequest extends AbstractRequest {
     private static final String RECORD_SET_KEY_NAME = "record_set";
 
     public static class Builder extends AbstractRequest.Builder<ProduceRequest> {
-        private short acks;
-        private int timeout;
-        private Map<TopicPartition, MemoryRecords> partitionRecords;
+        private final short acks;
+        private final int timeout;
+        private final Map<TopicPartition, MemoryRecords> partitionRecords;
 
         public Builder(short acks, int timeout, Map<TopicPartition, MemoryRecords> partitionRecords) {
             super(ApiKeys.PRODUCE);
@@ -55,27 +55,11 @@ public class ProduceRequest extends AbstractRequest {
             this.partitionRecords = partitionRecords;
         }
 
-        public Builder setAcks(short acks) {
-            this.acks = acks;
-            return this;
-        }
-
-        public Builder setTimeout(int timeout) {
-            this.timeout = timeout;
-            return this;
-        }
-
-        public Builder setPartitionRecords(Map<TopicPartition, MemoryRecords> partitionRecords) {
-            this.partitionRecords = partitionRecords;
-            return this;
-        }
-
         @Override
         public ProduceRequest build() {
             short version = version();
             if (version < 2) {
-                throw new UnsupportedVersionException("ProduceRequest " +
-                        "versions older than 2 are not supported.");
+                throw new UnsupportedVersionException("ProduceRequest versions older than 2 are not supported.");
             }
             return new ProduceRequest(version, acks, timeout, partitionRecords);
         }
@@ -97,8 +81,7 @@ public class ProduceRequest extends AbstractRequest {
     private final Map<TopicPartition, MemoryRecords> partitionRecords;
 
     private ProduceRequest(short version, short acks, int timeout, Map<TopicPartition, MemoryRecords> partitionRecords) {
-        super(new Struct(ProtoUtils.requestSchema(ApiKeys.PRODUCE.id, version)),
-                version);
+        super(new Struct(ProtoUtils.requestSchema(ApiKeys.PRODUCE.id, version)), version);
         Map<String, Map<Integer, MemoryRecords>> recordsByTopic = CollectionUtils.groupDataByTopic(partitionRecords);
         struct.set(ACKS_KEY_NAME, acks);
         struct.set(TIMEOUT_KEY_NAME, timeout);
@@ -182,9 +165,7 @@ public class ProduceRequest extends AbstractRequest {
     }
 
     public static ProduceRequest parse(ByteBuffer buffer, int versionId) {
-        return new ProduceRequest(
-                ProtoUtils.parseRequest(ApiKeys.PRODUCE.id, versionId, buffer),
-                (short) versionId);
+        return new ProduceRequest(ProtoUtils.parseRequest(ApiKeys.PRODUCE.id, versionId, buffer), (short) versionId);
     }
 
     public static ProduceRequest parse(ByteBuffer buffer) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslHandshakeRequest.java
@@ -74,8 +74,7 @@ public class SaslHandshakeRequest extends AbstractRequest {
     }
 
     public static SaslHandshakeRequest parse(ByteBuffer buffer, int versionId) {
-        return new SaslHandshakeRequest(
-                ProtoUtils.parseRequest(ApiKeys.SASL_HANDSHAKE.id, versionId, buffer),
+        return new SaslHandshakeRequest(ProtoUtils.parseRequest(ApiKeys.SASL_HANDSHAKE.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaRequest.java
@@ -37,10 +37,10 @@ public class StopReplicaRequest extends AbstractRequest {
     private static final String PARTITION_KEY_NAME = "partition";
 
     public static class Builder extends AbstractRequest.Builder<StopReplicaRequest> {
-        private int controllerId;
-        private int controllerEpoch;
-        private boolean deletePartitions;
-        private Set<TopicPartition> partitions;
+        private final int controllerId;
+        private final int controllerEpoch;
+        private final boolean deletePartitions;
+        private final Set<TopicPartition> partitions;
 
         public Builder(int controllerId, int controllerEpoch, boolean deletePartitions,
                        Set<TopicPartition> partitions) {
@@ -77,8 +77,7 @@ public class StopReplicaRequest extends AbstractRequest {
 
     private StopReplicaRequest(int controllerId, int controllerEpoch, boolean deletePartitions,
                                Set<TopicPartition> partitions, short version) {
-        super(new Struct(ProtoUtils.requestSchema(ApiKeys.STOP_REPLICA.id, version)),
-                version);
+        super(new Struct(ProtoUtils.requestSchema(ApiKeys.STOP_REPLICA.id, version)), version);
 
         struct.set(CONTROLLER_ID_KEY_NAME, controllerId);
         struct.set(CONTROLLER_EPOCH_KEY_NAME, controllerEpoch);
@@ -150,8 +149,7 @@ public class StopReplicaRequest extends AbstractRequest {
     }
 
     public static StopReplicaRequest parse(ByteBuffer buffer, int versionId) {
-        return new StopReplicaRequest(
-                ProtoUtils.parseRequest(ApiKeys.STOP_REPLICA.id, versionId, buffer),
+        return new StopReplicaRequest(ProtoUtils.parseRequest(ApiKeys.STOP_REPLICA.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupRequest.java
@@ -36,10 +36,10 @@ public class SyncGroupRequest extends AbstractRequest {
     public static final String GROUP_ASSIGNMENT_KEY_NAME = "group_assignment";
 
     public static class Builder extends AbstractRequest.Builder<SyncGroupRequest> {
-        private String groupId;
-        private int generationId;
-        private String memberId;
-        private Map<String, ByteBuffer> groupAssignment;
+        private final String groupId;
+        private final int generationId;
+        private final String memberId;
+        private final Map<String, ByteBuffer> groupAssignment;
 
         public Builder(String groupId, int generationId, String memberId,
                        Map<String, ByteBuffer> groupAssignment) {
@@ -50,30 +50,9 @@ public class SyncGroupRequest extends AbstractRequest {
             this.groupAssignment = groupAssignment;
         }
 
-        public Builder setGroupId(String groupId) {
-            this.groupId = groupId;
-            return this;
-        }
-
-        public Builder setGenerationId(int generationId) {
-            this.generationId = generationId;
-            return this;
-        }
-
-        public Builder setMemberId(String memberId) {
-            this.memberId = memberId;
-            return this;
-        }
-
-        public Builder setGroupAssignment(Map<String, ByteBuffer> groupAssignment) {
-            this.groupAssignment = groupAssignment;
-            return this;
-        }
-
         @Override
         public SyncGroupRequest build() {
-            return new SyncGroupRequest(groupId, generationId, memberId,
-                    groupAssignment, version());
+            return new SyncGroupRequest(groupId, generationId, memberId, groupAssignment, version());
         }
 
         @Override
@@ -85,7 +64,7 @@ public class SyncGroupRequest extends AbstractRequest {
                     append(", memberId=").append(memberId).
                     append(", groupAssignment=").
                     append(Utils.join(groupAssignment.keySet(), ",")).
-                    append(")"); // should we print groupAssignment values as well?  If so, as hex?
+                    append(")");
             return bld.toString();
         }
     }
@@ -96,8 +75,7 @@ public class SyncGroupRequest extends AbstractRequest {
 
     private SyncGroupRequest(String groupId, int generationId, String memberId,
                              Map<String, ByteBuffer> groupAssignment, short version) {
-        super(new Struct(ProtoUtils.requestSchema(ApiKeys.SYNC_GROUP.id, version)),
-                version);
+        super(new Struct(ProtoUtils.requestSchema(ApiKeys.SYNC_GROUP.id, version)), version);
         struct.set(GROUP_ID_KEY_NAME, groupId);
         struct.set(GENERATION_ID_KEY_NAME, generationId);
         struct.set(MEMBER_ID_KEY_NAME, memberId);
@@ -164,8 +142,7 @@ public class SyncGroupRequest extends AbstractRequest {
     }
 
     public static SyncGroupRequest parse(ByteBuffer buffer, int versionId) {
-        return new SyncGroupRequest(
-                ProtoUtils.parseRequest(ApiKeys.SYNC_GROUP.id, versionId, buffer),
+        return new SyncGroupRequest(ProtoUtils.parseRequest(ApiKeys.SYNC_GROUP.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -32,10 +32,10 @@ import java.util.Set;
 
 public class UpdateMetadataRequest extends AbstractRequest {
     public static class Builder extends AbstractRequest.Builder<UpdateMetadataRequest> {
-        private int controllerId;
-        private int controllerEpoch;
-        private Map<TopicPartition, PartitionState> partitionStates;
-        private Set<Broker> liveBrokers;
+        private final int controllerId;
+        private final int controllerEpoch;
+        private final Map<TopicPartition, PartitionState> partitionStates;
+        private final Set<Broker> liveBrokers;
 
         public Builder(int controllerId, int controllerEpoch,
                        Map<TopicPartition, PartitionState> partitionStates,
@@ -294,8 +294,7 @@ public class UpdateMetadataRequest extends AbstractRequest {
     }
 
     public static UpdateMetadataRequest parse(ByteBuffer buffer, int versionId) {
-        return new UpdateMetadataRequest(
-                ProtoUtils.parseRequest(ApiKeys.UPDATE_METADATA_KEY.id, versionId, buffer),
+        return new UpdateMetadataRequest(ProtoUtils.parseRequest(ApiKeys.UPDATE_METADATA_KEY.id, versionId, buffer),
                 (short) versionId);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -282,10 +282,16 @@ public class MockClient implements KafkaClient {
     }
 
     @Override
-    public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder requestBuilder,
-                                          long createdTimeMs, boolean expectResponse, RequestCompletionHandler callback) {
-        return new ClientRequest(nodeId, requestBuilder, 0, "mockClientId",
-                createdTimeMs, expectResponse, callback);
+    public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
+                                          boolean expectResponse) {
+        return newClientRequest(nodeId, requestBuilder, createdTimeMs, expectResponse, null);
+    }
+
+    @Override
+    public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
+                                          boolean expectResponse, RequestCompletionHandler callback) {
+        return new ClientRequest(nodeId, requestBuilder, 0, "mockClientId", createdTimeMs,
+                expectResponse, callback);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -86,7 +86,7 @@ public class NetworkClientTest {
         MetadataRequest.Builder builder =
                 new MetadataRequest.Builder(Arrays.asList("test"));
         long now = time.milliseconds();
-        ClientRequest request = client.newClientRequest("5", builder, now, false, null);
+        ClientRequest request = client.newClientRequest("5", builder, now, false);
         client.send(request, now);
         client.poll(1, time.milliseconds());
     }
@@ -114,8 +114,7 @@ public class NetworkClientTest {
         assertTrue("The client should be ready", client.isReady(node, time.milliseconds()));
 
         ProduceRequest.Builder builder = new ProduceRequest.Builder((short) 1, 1000, Collections.<TopicPartition, MemoryRecords>emptyMap());
-        ClientRequest request = client.newClientRequest(
-                node.idString(), builder, time.milliseconds(), true, null);
+        ClientRequest request = client.newClientRequest(node.idString(), builder, time.milliseconds(), true);
         client.send(request, time.milliseconds());
         assertEquals("There should be 1 in-flight request after send", 1,
                 client.inFlightRequestCount(node.idString()));
@@ -247,8 +246,7 @@ public class NetworkClientTest {
         MetadataRequest.Builder builder =
                 new MetadataRequest.Builder(Collections.<String>emptyList());
         long now = time.milliseconds();
-        ClientRequest request = client.newClientRequest(
-                node.idString(), builder, now, true, null);
+        ClientRequest request = client.newClientRequest(node.idString(), builder, now, true);
         client.send(request, now);
         client.poll(requestTimeoutMs, now);
         assertEquals(1, client.inFlightRequestCount(node.idString()));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -51,95 +51,90 @@ public class RequestResponseTest {
 
     @Test
     public void testSerialization() throws Exception {
-        try {
-            checkSerialization(createRequestHeader(), null);
-            checkSerialization(createResponseHeader(), null);
-            checkSerialization(createGroupCoordinatorRequest());
-            checkSerialization(createGroupCoordinatorRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createGroupCoordinatorResponse(), null);
-            checkSerialization(createControlledShutdownRequest());
-            checkSerialization(createControlledShutdownResponse(), null);
-            checkSerialization(createControlledShutdownRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createFetchRequest(3));
-            checkSerialization(createFetchRequest(3).getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createFetchResponse(), null);
-            checkSerialization(createHeartBeatRequest());
-            checkSerialization(createHeartBeatRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createHeartBeatResponse(), null);
-            checkSerialization(createJoinGroupRequest(1));
-            checkSerialization(createJoinGroupRequest(0).getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createJoinGroupRequest(1).getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createJoinGroupResponse(), null);
-            checkSerialization(createLeaveGroupRequest());
-            checkSerialization(createLeaveGroupRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createLeaveGroupResponse(), null);
-            checkSerialization(createListGroupsRequest());
-            checkSerialization(createListGroupsRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createListGroupsResponse(), null);
-            checkSerialization(createDescribeGroupRequest());
-            checkSerialization(createDescribeGroupRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createDescribeGroupResponse(), null);
-            checkSerialization(createListOffsetRequest(1));
-            checkSerialization(createListOffsetRequest(1).getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createListOffsetResponse(1), null);
-            checkSerialization(MetadataRequest.allTopics((short) 2));
-            checkSerialization(createMetadataRequest(1, Arrays.asList("topic1")));
-            checkSerialization(createMetadataRequest(1, Arrays.asList("topic1")).getErrorResponse(new UnknownServerException()), 1);
-            checkSerialization(createMetadataResponse(2), null);
-            checkSerialization(createMetadataRequest(2, Arrays.asList("topic1")).getErrorResponse(new UnknownServerException()), 2);
-            checkSerialization(createOffsetCommitRequest(2));
-            checkSerialization(createOffsetCommitRequest(2).getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createOffsetCommitResponse(), null);
-            checkSerialization(createOffsetFetchRequest());
-            checkSerialization(createOffsetFetchRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createOffsetFetchResponse(), null);
-            checkSerialization(createProduceRequest());
-            checkSerialization(createProduceRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createProduceResponse(), null);
-            checkSerialization(createStopReplicaRequest(true));
-            checkSerialization(createStopReplicaRequest(false));
-            checkSerialization(createStopReplicaRequest(true).getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createStopReplicaResponse(), null);
-            checkSerialization(createUpdateMetadataRequest(2, "rack1"));
-            checkSerialization(createUpdateMetadataRequest(2, null));
-            checkSerialization(createUpdateMetadataRequest(2, "rack1").getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createUpdateMetadataResponse(), null);
-            checkSerialization(createLeaderAndIsrRequest());
-            checkSerialization(createLeaderAndIsrRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createLeaderAndIsrResponse(), null);
-            checkSerialization(createSaslHandshakeRequest());
-            checkSerialization(createSaslHandshakeRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createSaslHandshakeResponse(), null);
-            checkSerialization(createApiVersionRequest());
-            checkSerialization(createApiVersionRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createApiVersionResponse(), null);
-            checkSerialization(createCreateTopicRequest());
-            checkSerialization(createCreateTopicRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createCreateTopicResponse(), null);
-            checkSerialization(createDeleteTopicsRequest());
-            checkSerialization(createDeleteTopicsRequest().getErrorResponse(new UnknownServerException()), null);
-            checkSerialization(createDeleteTopicsResponse(), null);
-            checkOlderFetchVersions();
-            checkSerialization(createMetadataResponse(0), 0);
-            checkSerialization(createMetadataResponse(1), 1);
-            checkSerialization(createMetadataRequest(1, Arrays.asList("topic1")).getErrorResponse(new UnknownServerException()), 1);
-            checkSerialization(createOffsetCommitRequest(0), 0);
-            checkSerialization(createOffsetCommitRequest(0).getErrorResponse(new UnknownServerException()), 0);
-            checkSerialization(createOffsetCommitRequest(1), 1);
-            checkSerialization(createOffsetCommitRequest(1).getErrorResponse(new UnknownServerException()), 1);
-            checkSerialization(createJoinGroupRequest(0), 0);
-            checkSerialization(createUpdateMetadataRequest(0, null), 0);
-            checkSerialization(createUpdateMetadataRequest(0, null).getErrorResponse(new UnknownServerException()), 0);
-            checkSerialization(createUpdateMetadataRequest(1, null), 1);
-            checkSerialization(createUpdateMetadataRequest(1, "rack1"), 1);
-            checkSerialization(createUpdateMetadataRequest(1, null).getErrorResponse(new UnknownServerException()), 1);
-            checkSerialization(createListOffsetRequest(0), 0);
-            checkSerialization(createListOffsetRequest(0).getErrorResponse(new UnknownServerException()), 0);
-            checkSerialization(createListOffsetResponse(0), 0);
-        } catch (Exception e) {
-            log.info("STACK TRACE: cause " + e.getStackTrace(), e.getCause());
-            throw e;
-        }
+        checkSerialization(createRequestHeader(), null);
+        checkSerialization(createResponseHeader(), null);
+        checkSerialization(createGroupCoordinatorRequest());
+        checkSerialization(createGroupCoordinatorRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createGroupCoordinatorResponse(), null);
+        checkSerialization(createControlledShutdownRequest());
+        checkSerialization(createControlledShutdownResponse(), null);
+        checkSerialization(createControlledShutdownRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createFetchRequest(3));
+        checkSerialization(createFetchRequest(3).getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createFetchResponse(), null);
+        checkSerialization(createHeartBeatRequest());
+        checkSerialization(createHeartBeatRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createHeartBeatResponse(), null);
+        checkSerialization(createJoinGroupRequest(1));
+        checkSerialization(createJoinGroupRequest(0).getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createJoinGroupRequest(1).getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createJoinGroupResponse(), null);
+        checkSerialization(createLeaveGroupRequest());
+        checkSerialization(createLeaveGroupRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createLeaveGroupResponse(), null);
+        checkSerialization(createListGroupsRequest());
+        checkSerialization(createListGroupsRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createListGroupsResponse(), null);
+        checkSerialization(createDescribeGroupRequest());
+        checkSerialization(createDescribeGroupRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createDescribeGroupResponse(), null);
+        checkSerialization(createListOffsetRequest(1));
+        checkSerialization(createListOffsetRequest(1).getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createListOffsetResponse(1), null);
+        checkSerialization(MetadataRequest.allTopics((short) 2));
+        checkSerialization(createMetadataRequest(1, Arrays.asList("topic1")));
+        checkSerialization(createMetadataRequest(1, Arrays.asList("topic1")).getErrorResponse(new UnknownServerException()), 1);
+        checkSerialization(createMetadataResponse(2), null);
+        checkSerialization(createMetadataRequest(2, Arrays.asList("topic1")).getErrorResponse(new UnknownServerException()), 2);
+        checkSerialization(createOffsetCommitRequest(2));
+        checkSerialization(createOffsetCommitRequest(2).getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createOffsetCommitResponse(), null);
+        checkSerialization(createOffsetFetchRequest());
+        checkSerialization(createOffsetFetchRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createOffsetFetchResponse(), null);
+        checkSerialization(createProduceRequest());
+        checkSerialization(createProduceRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createProduceResponse(), null);
+        checkSerialization(createStopReplicaRequest(true));
+        checkSerialization(createStopReplicaRequest(false));
+        checkSerialization(createStopReplicaRequest(true).getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createStopReplicaResponse(), null);
+        checkSerialization(createUpdateMetadataRequest(2, "rack1"));
+        checkSerialization(createUpdateMetadataRequest(2, null));
+        checkSerialization(createUpdateMetadataRequest(2, "rack1").getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createUpdateMetadataResponse(), null);
+        checkSerialization(createLeaderAndIsrRequest());
+        checkSerialization(createLeaderAndIsrRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createLeaderAndIsrResponse(), null);
+        checkSerialization(createSaslHandshakeRequest());
+        checkSerialization(createSaslHandshakeRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createSaslHandshakeResponse(), null);
+        checkSerialization(createApiVersionRequest());
+        checkSerialization(createApiVersionRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createApiVersionResponse(), null);
+        checkSerialization(createCreateTopicRequest());
+        checkSerialization(createCreateTopicRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createCreateTopicResponse(), null);
+        checkSerialization(createDeleteTopicsRequest());
+        checkSerialization(createDeleteTopicsRequest().getErrorResponse(new UnknownServerException()), null);
+        checkSerialization(createDeleteTopicsResponse(), null);
+        checkOlderFetchVersions();
+        checkSerialization(createMetadataResponse(0), 0);
+        checkSerialization(createMetadataResponse(1), 1);
+        checkSerialization(createMetadataRequest(1, Arrays.asList("topic1")).getErrorResponse(new UnknownServerException()), 1);
+        checkSerialization(createOffsetCommitRequest(0), 0);
+        checkSerialization(createOffsetCommitRequest(0).getErrorResponse(new UnknownServerException()), 0);
+        checkSerialization(createOffsetCommitRequest(1), 1);
+        checkSerialization(createOffsetCommitRequest(1).getErrorResponse(new UnknownServerException()), 1);
+        checkSerialization(createJoinGroupRequest(0), 0);
+        checkSerialization(createUpdateMetadataRequest(0, null), 0);
+        checkSerialization(createUpdateMetadataRequest(0, null).getErrorResponse(new UnknownServerException()), 0);
+        checkSerialization(createUpdateMetadataRequest(1, null), 1);
+        checkSerialization(createUpdateMetadataRequest(1, "rack1"), 1);
+        checkSerialization(createUpdateMetadataRequest(1, null).getErrorResponse(new UnknownServerException()), 1);
+        checkSerialization(createListOffsetRequest(0), 0);
+        checkSerialization(createListOffsetRequest(0).getErrorResponse(new UnknownServerException()), 0);
+        checkSerialization(createListOffsetResponse(0), 0);
     }
 
     private void checkOlderFetchVersions() throws Exception {
@@ -209,8 +204,7 @@ public class RequestResponseTest {
     @Test
     public void verifyFetchResponseFullWrite() throws Exception {
         FetchResponse fetchResponse = createFetchResponse();
-        RequestHeader header = new RequestHeader(ApiKeys.FETCH.id,
-                ProtoUtils.latestVersion(ApiKeys.FETCH.id),
+        RequestHeader header = new RequestHeader(ApiKeys.FETCH.id, ProtoUtils.latestVersion(ApiKeys.FETCH.id),
                 "client", 15);
 
         Send send = fetchResponse.toSend("1", header);
@@ -355,16 +349,14 @@ public class RequestResponseTest {
     @SuppressWarnings("deprecation")
     private ListOffsetRequest createListOffsetRequest(int version) {
         if (version == 0) {
-            Map<TopicPartition, ListOffsetRequest.PartitionData> offsetData = new HashMap<>();
-            offsetData.put(new TopicPartition("test", 0), new ListOffsetRequest.PartitionData(1000000L, 10));
-            return new ListOffsetRequest.Builder().setOffsetData(offsetData).
-                    setVersion((short) version).build();
+            Map<TopicPartition, ListOffsetRequest.PartitionData> offsetData = Collections.singletonMap(
+                    new TopicPartition("test", 0),
+                    new ListOffsetRequest.PartitionData(1000000L, 10));
+            return new ListOffsetRequest.Builder().setOffsetData(offsetData).setVersion((short) version).build();
         } else if (version == 1) {
-            Map<TopicPartition, Long> offsetData = new HashMap<>();
-            offsetData.put(new TopicPartition("test", 0), 1000000L);
-            return new ListOffsetRequest.Builder().setTargetTimes(offsetData).
-                    setReplicaId(ListOffsetRequest.CONSUMER_REPLICA_ID).
-                    setVersion((short) version).build();
+            Map<TopicPartition, Long> offsetData = Collections.singletonMap(
+                    new TopicPartition("test", 0), 1000000L);
+            return new ListOffsetRequest.Builder().setTargetTimes(offsetData).setVersion((short) version).build();
         } else {
             throw new IllegalArgumentException("Illegal ListOffsetRequest version " + version);
         }

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -190,6 +190,8 @@ class RequestSendThread(val controllerId: Int,
               val clientRequest = networkClient.newClientRequest(
                   brokerNode.idString, requestBuilder, time.milliseconds(), true, null)
               val abstractRequest = clientRequest.requestBuilder().build()
+              val clientRequest = networkClient.newClientRequest(brokerNode.idString, requestBuilder,
+                time.milliseconds(), true)
               clientResponse = networkClient.blockingSendAndReceive(clientRequest)(time)
               isSendSuccessful = true
             }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -689,8 +689,9 @@ class KafkaController(val config: KafkaConfig, zkUtils: ZkUtils, val brokerState
     onControllerResignation()
   }
 
-  def sendRequest(brokerId: Int, apiKey: ApiKeys, apiVersion: Option[Short], request: AbstractRequest.Builder[_ <: AbstractRequest], callback: AbstractResponse => Unit = null) = {
-    controllerContext.controllerChannelManager.sendRequest(brokerId, apiKey, apiVersion, request, callback)
+  def sendRequest(brokerId: Int, apiKey: ApiKeys, request: AbstractRequest.Builder[_ <: AbstractRequest],
+                  callback: AbstractResponse => Unit = null) = {
+    controllerContext.controllerChannelManager.sendRequest(brokerId, apiKey, request, callback)
   }
 
   def incrementControllerEpoch(zkClient: ZkClient) = {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -427,8 +427,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
               // send the controlled shutdown request
               val controlledShutdownRequest = new ControlledShutdownRequest.Builder(config.brokerId)
-              val request = networkClient.newClientRequest(
-                  node(prevController).idString, controlledShutdownRequest, time.milliseconds(), true, null)
+              val request = networkClient.newClientRequest(node(prevController).idString, controlledShutdownRequest,
+                time.milliseconds(), true)
               val clientResponse = networkClient.blockingSendAndReceive(request)(time)
 
               val shutdownResponse = clientResponse.responseBody.asInstanceOf[ControlledShutdownResponse]

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -244,8 +244,8 @@ class ReplicaFetcherThread(name: String,
       if (!networkClient.blockingReady(sourceNode, socketTimeout)(time))
         throw new SocketTimeoutException(s"Failed to connect within $socketTimeout ms")
       else {
-        val clientRequest = networkClient.newClientRequest(
-            sourceBroker.id.toString, requestBuilder, time.milliseconds(), true, null)
+        val clientRequest = networkClient.newClientRequest(sourceBroker.id.toString, requestBuilder,
+          time.milliseconds(), true)
         networkClient.blockingSendAndReceive(clientRequest)(time)
       }
     }

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -260,14 +260,13 @@ class ReplicaFetcherThread(name: String,
   private def earliestOrLatestOffset(topicPartition: TopicPartition, earliestOrLatest: Long, consumerId: Int): Long = {
     val requestBuilder = if (brokerConfig.interBrokerProtocolVersion >= KAFKA_0_10_1_IV2) {
         val partitions = Map(topicPartition -> (earliestOrLatest: java.lang.Long))
-        new ListOffsetRequest.Builder().
-            setReplicaId(consumerId).
+        new ListOffsetRequest.Builder(consumerId).
             setTargetTimes(partitions.asJava).
             setVersion(1)
       } else {
         val partitions = Map(topicPartition -> new ListOffsetRequest.PartitionData(earliestOrLatest, 1))
-        new ListOffsetRequest.Builder().
-            setReplicaId(consumerId).setOffsetData(partitions.asJava).
+        new ListOffsetRequest.Builder(consumerId).
+            setOffsetData(partitions.asJava).
             setVersion(0)
       }
     val clientResponse = sendRequest(requestBuilder)
@@ -311,9 +310,9 @@ class ReplicaFetcherThread(name: String,
 object ReplicaFetcherThread {
 
   private[server] class FetchRequest(val underlying: JFetchRequest.Builder) extends AbstractFetcherThread.FetchRequest {
-    def isEmpty: Boolean = underlying.getFetchData().isEmpty
+    def isEmpty: Boolean = underlying.fetchData().isEmpty
     def offset(topicPartition: TopicPartition): Long =
-      underlying.getFetchData().asScala(topicPartition).offset
+      underlying.fetchData().asScala(topicPartition).offset
   }
 
   private[server] class PartitionData(val underlying: FetchResponse.PartitionData) extends AbstractFetcherThread.PartitionData {

--- a/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
@@ -146,7 +146,7 @@ class LeaderElectionTest extends ZooKeeperTestHarness {
       val requestBuilder = new LeaderAndIsrRequest.Builder(
           controllerId, staleControllerEpoch, partitionStates.asJava, nodes.toSet.asJava)
 
-      controllerChannelManager.sendRequest(brokerId2, ApiKeys.LEADER_AND_ISR, None, requestBuilder,
+      controllerChannelManager.sendRequest(brokerId2, ApiKeys.LEADER_AND_ISR, requestBuilder,
         staleControllerEpochCallback)
       TestUtils.waitUntilTrue(() => staleControllerEpochDetected, "Controller epoch should be stale")
       assertTrue("Stale controller epoch not detected by the broker", staleControllerEpochDetected)


### PR DESCRIPTION
- Remove unused setters
- Make fields final
- Allow for longer lines in some cases
- Remove `get` prefix
- A few other bits and pieces